### PR TITLE
Virtual files, Nano-ID, lots of bugfixes, more reliable shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,6 +2,12 @@
 # It is not intended for manual editing.
 [[package]]
 name = "autocfg"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+
+[[package]]
+name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
@@ -84,6 +90,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +149,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -383,7 +404,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
@@ -523,6 +544,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanoid"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6226bc4e142124cb44e309a37a04cd9bb10e740d8642855441d3b14808f635e"
+dependencies = [
+ "rand 0.6.5",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,7 +587,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "num-traits",
 ]
 
@@ -567,7 +597,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
@@ -608,7 +638,7 @@ version = "0.9.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "cc",
  "libc",
  "pkg-config",
@@ -668,6 +698,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-staticfile",
+ "nanoid",
  "tokio",
  "tokio-tungstenite",
  "tungstenite",
@@ -712,15 +743,44 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.7",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc 0.1.0",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg",
+ "rand_xorshift",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -730,8 +790,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -744,11 +819,82 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -878,7 +1024,7 @@ checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if",
  "libc",
- "rand",
+ "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
@@ -996,7 +1142,7 @@ dependencies = [
  "input_buffer",
  "log",
  "native-tls",
- "rand",
+ "rand 0.7.3",
  "sha-1",
  "url",
  "utf-8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,7 +691,7 @@ checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
 name = "pollnet"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "futures",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pollnet"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["probable-basilisk <basilisk@mtknn.com>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ futures-util = "*"
 hyper = "0.13.6"
 hyper-staticfile = "0.5.3"
 http = "0.2"
+nanoid = "0.3.0"
 
 [dependencies.tokio]
 version = "*"

--- a/bindings/luajit/pollnet.lua
+++ b/bindings/luajit/pollnet.lua
@@ -67,6 +67,13 @@ local function init_ctx()
   assert(_ctx ~= nil)
 end
 
+local function init_ctx_hack_static()
+  if _ctx then return end
+  _ctx = pollnet.pollnet_get_or_init_static()
+  assert(_ctx ~= nil)
+  pollnet.pollnet_close_all(_ctx)
+end
+
 local function shutdown_ctx()
   if not _ctx then return end
   pollnet.pollnet_shutdown(_ctx)
@@ -214,7 +221,8 @@ local function serve_http(addr, dir, scratch_size)
 end
 
 return {
-  init = init_ctx, 
+  init = init_ctx,
+  init_hack_static = init_ctx_hack_static,
   shutdown = shutdown_ctx, 
   open_ws = open_ws, 
   listen_ws = listen_ws,

--- a/bindings/luajit/pollnet.lua
+++ b/bindings/luajit/pollnet.lua
@@ -31,9 +31,11 @@ end)
 local ffi = require("ffi")
 ffi.cdef[[
 struct pnctx* pollnet_init();
+struct pnctx* pollnet_get_or_init_static();
 void pollnet_shutdown(struct pnctx* ctx);
 unsigned int pollnet_open_ws(struct pnctx* ctx, const char* url);
 void pollnet_close(struct pnctx* ctx, unsigned int handle);
+void pollnet_close_all(struct pnctx* ctx);
 void pollnet_send(struct pnctx* ctx, unsigned int handle, const char* msg);
 unsigned int pollnet_update(struct pnctx* ctx, unsigned int handle);
 int pollnet_get(struct pnctx* ctx, unsigned int handle, char* dest, unsigned int dest_size);
@@ -43,7 +45,7 @@ unsigned int pollnet_listen_ws(struct pnctx* ctx, const char* addr);
 unsigned int pollnet_serve_static_http(struct pnctx* ctx, const char* addr, const char* serve_dir);
 unsigned int pollnet_serve_http(struct pnctx* ctx, const char* addr);
 void pollnet_add_virtual_file(struct pnctx* ctx, unsigned int handle, const char* filename, const char* filedata, unsigned int filesize);
-void pollnet_remove_virtual_file(struct pnctx* ctx, unsigned int handle, const char* filename)
+void pollnet_remove_virtual_file(struct pnctx* ctx, unsigned int handle, const char* filename);
 ]]
 
 local POLLNET_RESULT_CODES = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,6 +396,7 @@ impl PollnetContext {
                 _ => (),
             }
         }
+        self.sockets.clear(); // everything should be closed and safely droppable
     }
 
     fn close(&mut self, handle: u32) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -519,7 +519,6 @@ pub extern fn pollnet_init() -> *mut PollnetContext {
     Box::into_raw(Box::new(PollnetContext::new()))
 }
 
-
 #[no_mangle]
 pub extern fn pollnet_shutdown(ctx: *mut PollnetContext) {
     println!("Pollnet: requested ctx close!");
@@ -531,7 +530,6 @@ pub extern fn pollnet_shutdown(ctx: *mut PollnetContext) {
     drop(b);
     println!("Pollnet: Everything should be dead now!");
 }
-
 
 #[no_mangle]
 pub extern fn pollnet_open_ws(ctx: *mut PollnetContext, url: *const c_char) -> u32 {
@@ -546,7 +544,6 @@ pub extern fn pollnet_listen_ws(ctx: *mut PollnetContext, addr: *const c_char) -
     let ctx = unsafe{&mut *ctx};
     ctx.listen_ws(addr)
 }
-
 
 #[no_mangle]
 pub extern fn pollnet_serve_static_http(ctx: *mut PollnetContext, addr: *const c_char, serve_dir: *const c_char) -> u32 {
@@ -667,4 +664,15 @@ pub extern fn pollnet_get_error(ctx: *mut PollnetContext, handle: u32, dest: *mu
     } else {
         -1
     }
+}
+
+static mut HACKSTATICCONTEXT: *mut PollnetContext = 0 as *mut PollnetContext;
+
+#[no_mangle]
+pub unsafe extern fn pollnet_get_or_init_static() -> *mut PollnetContext {
+    if HACKSTATICCONTEXT.is_null() {
+        println!("Pollnet: INITIALIZING HACK STATIC CONTEXT");
+        HACKSTATICCONTEXT = Box::into_raw(Box::new(PollnetContext::new()))
+    }
+    HACKSTATICCONTEXT
 }


### PR DESCRIPTION
Virtual files:
Can serve HTTP files from memory by setting virtual files. Lets you avoid having to have any on-disk file structure at all.

Nanoid:
Get a secure-ishly random string (useful for auth-type stuff)

Bugfixes:
Fewer panics, more returned errors.

Shutdown:
Hacked in a 200ms delay to let things like sockets gracefully close.